### PR TITLE
Proxy does not respect x_forwarded_proto, fails behind proxy/balancer

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,8 +34,9 @@ $pmURL = "http://127.0.0.1:8080/i2b2/rest/PMService/getServices";
 $pmCheckAllRequests = false;
 
 $WHITELIST = array(
-        "http" . (($_SERVER['SERVER_PORT'] == '443') ? 's' : '' ) . "://" . $_SERVER['HTTP_HOST'],
-        "http://services.i2b2.org",
+		"http://" . $_SERVER['HTTP_HOST'],
+        "https://" . $_SERVER['HTTP_HOST'],
+		"http://services.i2b2.org",
         "http://127.0.0.1:9090",
         "http://127.0.0.1:8080",
         "http://127.0.0.1",


### PR DESCRIPTION
Fixes wake-forest-ctsi/i2b2-webclient#6

Signed-off-by: Michael Horvath <mhorvath@wakehealth.edu>